### PR TITLE
Add Gemfile.lock back to the repo for Heroku.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,0 @@
-Gemfile.lock


### PR DESCRIPTION
Heorku seems to require the file to accept the push:

``` bash
tal:~/Projects/github-trello $ git push heroku master
Initializing repository, done.
Counting objects: 150, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (91/91), done.
Writing objects: 100% (150/150), 25.33 KiB | 0 bytes/s, done.
Total 150 (delta 44), reused 143 (delta 40)

-----> Ruby app detected
-----> Compiling Ruby/NoLockfile
!
!     Gemfile.lock required. Please check it in.
!

!     Push rejected, failed to compile Ruby app

To git@heroku.my-repo:my-repo-github-trello.git
! [remote rejected] master -> master (pre-receive hook declined)
error: failed to push some refs to
'git@heroku.my-repo:my-repo-github-trello.git'
```

Great project by the way! Thanks for making this :+1: 
